### PR TITLE
Fix tree-shaking: replace @mui/icons-material barrel imports

### DIFF
--- a/src/component/search-ui/filters/SearchUIFilters.tsx
+++ b/src/component/search-ui/filters/SearchUIFilters.tsx
@@ -5,7 +5,7 @@ import SearchUITemplatesMenu from './component/template/SearchUITemplatesMenu';
 import {useTranslation} from 'react-i18next';
 import {useSearchUIFiltersStore} from './state/store';
 import {Box, Chip, IconButton, SxProps} from '@mui/material';
-import {ExpandMore} from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import SearchUIAddFilter from './component/select/SearchUIAddFilter';
 import {CriterionContainer} from './CriterionContainer';
 import {PneButton, SearchUIDefaults} from '../../..';
@@ -177,7 +177,7 @@ export const SearchUIFilters = (props: Props) => {
                     size={'small'}
                     color={'primary'}
                 >
-                    <ExpandMore
+                    <ExpandMoreIcon
                         fontSize={'small'}
                         sx={{transform: showFilters ? 'rotate(180deg)' : 'rotate(-90deg)'}}
                     />

--- a/src/component/search-ui/filters/component/criterion/ProjectCurrencyCriterion.tsx
+++ b/src/component/search-ui/filters/component/criterion/ProjectCurrencyCriterion.tsx
@@ -4,7 +4,7 @@ import {Box, Chip, FormControlLabel, FormGroup, SxProps} from '@mui/material';
 import {useTranslation} from 'react-i18next';
 import Typography from '@mui/material/Typography';
 import {selectUnderChipSx} from '../select/style';
-import {ExpandMore} from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {AbstractEntity, PneCheckbox, PneSelect, ensure} from '../../../../..';
 import {SearchUIDefaultsContext} from "../../../SearchUIProvider";
 
@@ -52,7 +52,7 @@ export const ProjectCurrencyCriterion = () => {
         <Box sx={{position: 'relative'}}>
             <Chip
                 onDelete={() => setOpen(true)}
-                deleteIcon={<ExpandMore/>}
+                deleteIcon={<ExpandMoreIcon/>}
                 label={currency.displayName}
                 size={'small'}
             />

--- a/src/component/search-ui/filters/component/criterion/orders-search/OrdersSearchCountrySelect.tsx
+++ b/src/component/search-ui/filters/component/criterion/orders-search/OrdersSearchCountrySelect.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, useEffect, useState} from 'react';
 import {Box, Chip} from '@mui/material';
-import {ExpandMore} from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {useSearchUIFiltersStore} from "../../../state/store";
 import {selectUnderChipSx} from '../../select/style';
 import PneSelect from '../../../../../dropdown/PneSelect';
@@ -32,7 +32,7 @@ export const OrdersSearchCountrySelect = () => {
     return <Box sx={{position: 'relative'}}>
         <Chip
             onDelete={() => setOpen(true)}
-            deleteIcon={<ExpandMore/>}
+            deleteIcon={<ExpandMoreIcon/>}
             label={country ? country.displayName : t('react.searchUI.countrySelectPlaceholder')}
             size={'small'}
         />

--- a/src/component/search-ui/filters/component/select/SearchUIAddFilter.tsx
+++ b/src/component/search-ui/filters/component/select/SearchUIAddFilter.tsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import {CriterionTypeEnum} from '../../types';
 import {Box, SxProps} from '@mui/material';
 import {useTranslation} from 'react-i18next';
-import {ExpandMore} from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {PneButton, PneSelect} from '../../../../..';
 
 type Props = {
@@ -23,7 +23,7 @@ const SearchUIAddFilter = (props: Props) => {
         <PneButton
             onClick={() => setOpen(true)}
             size={'small'}
-            endIcon={<ExpandMore/>}
+            endIcon={<ExpandMoreIcon/>}
             sx={addFilterButtonSx}
         >{t('react.searchUI.addCriterion')}</PneButton>
         <PneSelect

--- a/src/component/search-ui/filters/component/select/SearchUIDateRangeSpecTypeSelect.tsx
+++ b/src/component/search-ui/filters/component/select/SearchUIDateRangeSpecTypeSelect.tsx
@@ -3,7 +3,7 @@ import {DATE_RANGE_SPEC_TYPES, DateRangeSpecType} from '../../types'
 import {Box, Chip, SxProps} from '@mui/material'
 import {useTranslation} from 'react-i18next'
 import {useSearchUIFiltersStore} from '../../state/store'
-import {ExpandMore} from '@mui/icons-material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import {selectUnderChipSx} from './style'
 import {PneSelect} from '../../../../..'
 
@@ -40,7 +40,7 @@ const SearchUIDateRangeSpecTypeSelect = () => {
     return <Box sx={{position: 'relative'}}>
         <Chip
             onDelete={() => setOpen(true)}
-            deleteIcon={<ExpandMore/>}
+            deleteIcon={<ExpandMoreIcon/>}
             label={optionRenderer(dateRangeSpec.dateRangeSpecType)}
             size={'small'}
         />

--- a/src/component/search-ui/filters/component/select/SearchUIExactSearchLabelSelect.tsx
+++ b/src/component/search-ui/filters/component/select/SearchUIExactSearchLabelSelect.tsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import {ExactCriterionSearchLabelEnum} from '../../types';
 import {Box, Chip} from '@mui/material';
 import {useTranslation} from 'react-i18next';
-import {ExpandMore} from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {selectUnderChipSx} from './style';
 import {PneSelect} from '../../../../..';
 
@@ -24,7 +24,7 @@ const SearchUIExactSearchLabelSelect = (props: IProps) => {
     return <Box sx={{position: 'relative'}}>
         <Chip
             onDelete={() => setOpen(true)}
-            deleteIcon={<ExpandMore/>}
+            deleteIcon={<ExpandMoreIcon/>}
             label={optionRenderer(value)}
             size={'small'}
         />

--- a/src/component/search-ui/filters/component/select/SearchUIGroupingDateTypeSelect.tsx
+++ b/src/component/search-ui/filters/component/select/SearchUIGroupingDateTypeSelect.tsx
@@ -4,7 +4,7 @@ import {Box, Chip} from '@mui/material';
 import {useTranslation} from 'react-i18next';
 import {useSearchUIFiltersStore} from '../../state/store';
 import {selectUnderChipSx} from './style';
-import {ExpandMore} from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {PneSelect} from '../../../../..';
 
 const SearchUIGroupingDateTypeSelect = () => {
@@ -18,7 +18,7 @@ const SearchUIGroupingDateTypeSelect = () => {
     return <Box sx={{position: 'relative'}}>
         <Chip
             onDelete={() => setOpen(true)}
-            deleteIcon={<ExpandMore/>}
+            deleteIcon={<ExpandMoreIcon/>}
             label={optionRenderer(dateType)}
             size={'small'}
         />

--- a/src/component/search-ui/filters/component/select/SearchUIOrderDateTypeSelect.tsx
+++ b/src/component/search-ui/filters/component/select/SearchUIOrderDateTypeSelect.tsx
@@ -3,7 +3,7 @@ import {ORDER_DATE_TYPES, OrderDate} from '../../types';
 import {Box, Chip, SxProps} from '@mui/material';
 import {useTranslation} from 'react-i18next';
 import {useSearchUIFiltersStore} from '../../state/store';
-import {ExpandMore} from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {selectUnderChipSx} from './style';
 import {PneSelect} from '../../../../..';
 
@@ -29,7 +29,7 @@ export const SearchUIOrderDateTypeSelect = () => {
     return <Box sx={{position: 'relative'}}>
         <Chip
             onDelete={() => setOpen(true)}
-            deleteIcon={<ExpandMore/>}
+            deleteIcon={<ExpandMoreIcon/>}
             label={optionRenderer(orderDateType)}
             size={'small'}
         />

--- a/src/component/search-ui/filters/component/select/SearchUIOrdersSearchLabelSelect.tsx
+++ b/src/component/search-ui/filters/component/select/SearchUIOrdersSearchLabelSelect.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {Box, Chip} from '@mui/material';
 import {useTranslation} from 'react-i18next';
-import {ExpandMore} from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {useSearchUIFiltersStore} from "../../state/store";
 import {SearchUICollapsableGroupSelect} from './SearchUICollapsableGroupSelect';
 
@@ -15,7 +15,7 @@ export const SearchUIOrdersSearchLabelSelect = () => {
     return <Box sx={{position: 'relative'}}>
         <Chip
             onDelete={() => setOpen(true)}
-            deleteIcon={<ExpandMore/>}
+            deleteIcon={<ExpandMoreIcon/>}
             label={optionRenderer(ordersSearchLabel)}
             size={'small'}
         />

--- a/src/component/search-ui/filters/component/select/SearchUIProcessorLogEntryTypeSelect.tsx
+++ b/src/component/search-ui/filters/component/select/SearchUIProcessorLogEntryTypeSelect.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Box, Chip } from '@mui/material'
-import { ExpandMore } from '@mui/icons-material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { selectUnderChipSx } from './style'
 import { AbstractEntity, PneSelect } from '../../../../..'
 import { useTranslation } from 'react-i18next'
@@ -28,7 +28,7 @@ const SearchUIProcessorLogEntryTypeSelect = (props: IProps) => {
     return <Box sx={{ position: 'relative' }}>
         <Chip
             onDelete={() => setOpen(true)}
-            deleteIcon={<ExpandMore/>}
+            deleteIcon={<ExpandMoreIcon/>}
             label={value ? value.displayName : t('react.chooseOne')}
             size={'small'}
         />

--- a/src/component/search-ui/filters/component/template/SearchUITemplatesMenu.tsx
+++ b/src/component/search-ui/filters/component/template/SearchUITemplatesMenu.tsx
@@ -5,7 +5,8 @@ import {SxProps} from '@mui/material/styles';
 // import {invokeCommonDeletionAlert} from '../../../../ConfirmAlertInvoker'; //TODO migration
 import {useTranslation} from 'react-i18next';
 import {useSearchUIFiltersStore} from '../../state/store';
-import {Close, ExpandMore} from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {SearchUITemplate} from "../../types";
 import {PneButton} from '../../../../..';
 
@@ -41,7 +42,7 @@ const SearchUITemplatesMenu = () => {
             onClick={handleOpen}
             size={'small'}
             color={'pneNeutral'}
-            endIcon={<ExpandMore/>}
+            endIcon={<ExpandMoreIcon/>}
             sx={templateTriggerSx}
             title={placeholder}
         >
@@ -72,7 +73,7 @@ const SearchUITemplatesMenu = () => {
                             onClick={() => handleRemoveTemplate(template)}
                             color={'primary'}
                         >
-                            <Close fontSize={'small'}/>
+                            <CloseIcon fontSize={'small'}/>
                         </IconButton>
                     </Box>
                 )}


### PR DESCRIPTION
Problem
pne-ui used barrel imports from @mui/icons-material (e.g. import { ExpandMore } from '@mui/icons-material'). In consumer apps this can prevent effective tree-shaking (especially with CJS output) and pull a large portion of the icons package into the final bundle.
Changes
Replaced all @mui/icons-material (root/barrel) imports with per-icon path imports:
import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
import CloseIcon from '@mui/icons-material/Close'
No functional logic changes intended—imports only.
Why
Per-icon imports are the most reliable way to keep consumer bundle sizes small and avoid bundlers including the full icons barrel.
How to verify
yarn build
Confirm no barrel imports remain:
grep -R \"from '@mui/icons-material'\" src
Confirm build outputs don’t contain barrel usage:
grep -R \"@mui/icons-material\" esm cjs
(should only show @mui/icons-material/<Icon> paths)
Files changed
src/component/search-ui/filters/SearchUIFilters.tsx
src/component/search-ui/filters/component/template/SearchUITemplatesMenu.tsx
src/component/search-ui/filters/component/select/SearchUIAddFilter.tsx
src/component/search-ui/filters/component/select/SearchUIExactSearchLabelSelect.tsx
src/component/search-ui/filters/component/select/SearchUIGroupingDateTypeSelect.tsx
src/component/search-ui/filters/component/select/SearchUIDateRangeSpecTypeSelect.tsx
src/component/search-ui/filters/component/select/SearchUIOrdersSearchLabelSelect.tsx
src/component/search-ui/filters/component/select/SearchUIOrderDateTypeSelect.tsx
src/component/search-ui/filters/component/select/SearchUIProcessorLogEntryTypeSelect.tsx
src/component/search-ui/filters/component/criterion/orders-search/OrdersSearchCountrySelect.tsx
src/component/search-ui/filters/component/criterion/ProjectCurrencyCriterion.tsx